### PR TITLE
Standard for interface address change and address usage area

### DIFF
--- a/routes.txt
+++ b/routes.txt
@@ -22,6 +22,7 @@ Network ID		Protocol	Upstream	     Downstream		Comment
 10.127.0.52/30		WireGuard	pan		 --> NeoSystem		
 10.127.0.56/30		Tinc		ucbvax		 --> Icecat-Explosion	No online time guarantee
 10.127.0.60/30		WireGuard	ucbvax		<--> pan
+10.127.0.64/30          Gre             Icecat-Explosion<--> Icecat-Notebook    No online time guarantee
 
 @1 --> Non-24H
 
@@ -34,8 +35,8 @@ Subnet			Name			Comment
 10.127.1.0/24		CROOM			For LAN in school
 10.127.2.0/24		NeoSystem VMs		Virtual Machine on NeoSystem
 10.127.3.0/24		pan hub			For non-multihome connection in Taiwan
-10.127.4.0/24		Icecat-Explosion	For Magicneko Explosion Network Interworking address
-172.24.5.0/24		Icecat-Mobile-devices 	for Mobile device internal network segment for testing connectivity quality, No SLA
+10.127.4.0/24		Icecat-Explosion	For Magicneko Explosion Network Interworking address (in Global)
+172.24.5.0/24		Icecat-Mobile-devices 	for Mobile device internal network segment for testing connectivity quality, No SLA (in China Mainland)
 
 
 +======================+


### PR DESCRIPTION
1. Update the interface ospf address
2. The address submitted by nextmoe-icecat divides the use area
3. This modification was jointly revised by the NextMoe team
4. Force synchronization of upstream version files

#简体中文版
1 更新接口地址，使用 NeoNetwork 的地址重新划分
2 由 NextMoe-icecat 提交的地址将标注使用区域
3 本次修改由 NextMoe 小组联合修改
4 强制同步上游版本